### PR TITLE
spring-boot-watch-pipeline-activity to 1.0.0

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: spring-boot-watch-pipeline-activity
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.0


### PR DESCRIPTION
Promote spring-boot-watch-pipeline-activity to version 1.0.0