### PR TITLE
spring-boot-rest-prometheus to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -39,7 +39,7 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2
 - name: spring-boot-watch-pipeline-activity
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.0


### PR DESCRIPTION
Promote spring-boot-rest-prometheus to version 0.0.2